### PR TITLE
feat(spec2sdk): render simple types as Pydantic RootModel

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ from spec2sdk.generators.entities import PythonType
 from spec2sdk.generators.predicates import is_instance
 from spec2sdk.generators.imports import Import
 from spec2sdk.generators.models.entities import TypeRenderer
-from spec2sdk.generators.models.renderers import render_alias_type, renderers
+from spec2sdk.generators.models.renderers import render_root_model, renderers
 from spec2sdk.main import generate
 
 
@@ -152,7 +152,7 @@ def convert_email_field(data_type: StringDataType) -> EmailPythonType:
 
 @renderers.register(predicate=is_instance(EmailPythonType))
 def render_email_field(py_type: EmailPythonType) -> TypeRenderer:
-    return render_alias_type(
+    return render_root_model(
         py_type,
         extra_imports=(Import(name="EmailStr", package="pydantic"),),
         content="EmailStr",

--- a/spec2sdk/generators/models/renderers.py
+++ b/spec2sdk/generators/models/renderers.py
@@ -34,7 +34,7 @@ def create_jinja_environment() -> Environment:
     return Environment(loader=FileSystemLoader(f"{Path(__file__).parent}/templates"))
 
 
-def render_alias_type(
+def render_root_model(
     py_type: PythonType,
     extra_imports: Sequence[Import] = (),
     content: str = "",
@@ -42,35 +42,35 @@ def render_alias_type(
     return TypeRenderer(
         imports=(
             *extra_imports,
-            *((Import(name="TypeAlias", package="typing"),) if py_type.name else ()),
+            *((Import(name="RootModel", package="pydantic"),) if py_type.name else ()),
         ),
-        content=f"{py_type.name}: TypeAlias = {content}" if py_type.name else None,
+        content=f"{py_type.name} = RootModel[{content}]" if py_type.name else None,
     )
 
 
 @renderers.register(predicate=is_instance(IntegerPythonType))
 def render_integer(py_type: IntegerPythonType) -> TypeRenderer:
-    return render_alias_type(py_type, content="int")
+    return render_root_model(py_type, content="int")
 
 
 @renderers.register(predicate=is_instance(FloatPythonType))
 def render_float(py_type: FloatPythonType) -> TypeRenderer:
-    return render_alias_type(py_type, content="float")
+    return render_root_model(py_type, content="float")
 
 
 @renderers.register(predicate=is_instance(BooleanPythonType))
 def render_boolean(py_type: BooleanPythonType) -> TypeRenderer:
-    return render_alias_type(py_type, content="bool")
+    return render_root_model(py_type, content="bool")
 
 
 @renderers.register(predicate=is_instance(StringPythonType))
 def render_string(py_type: StringPythonType) -> TypeRenderer:
-    return render_alias_type(py_type, content="str")
+    return render_root_model(py_type, content="str")
 
 
 @renderers.register(predicate=is_instance(OptionalPythonType))
 def render_optional(py_type: OptionalPythonType) -> TypeRenderer:
-    return render_alias_type(
+    return render_root_model(
         py_type=py_type,
         content=f"{py_type.inner_py_type.type_hint} | None",
     )
@@ -78,7 +78,7 @@ def render_optional(py_type: OptionalPythonType) -> TypeRenderer:
 
 @renderers.register(predicate=is_instance(ListPythonType))
 def render_list(py_type: ListPythonType) -> TypeRenderer:
-    return render_alias_type(
+    return render_root_model(
         py_type=py_type,
         content=f"list[{py_type.inner_py_type.type_hint}]",
     )
@@ -100,7 +100,7 @@ class File(NamedTuple):
 
 @renderers.register(predicate=is_instance(LiteralPythonType))
 def render_literal(py_type: LiteralPythonType) -> TypeRenderer:
-    return render_alias_type(
+    return render_root_model(
         py_type=py_type,
         extra_imports=(Import(name="Literal", package="typing"),),
         content="Literal[" + ",".join(repr(literal) for literal in py_type.literals) + "]",
@@ -152,7 +152,7 @@ def render_str_enum(py_type: StrEnumPythonType) -> TypeRenderer:
 
 @renderers.register(predicate=is_instance(UnionPythonType))
 def render_union(py_type: UnionPythonType) -> TypeRenderer:
-    return render_alias_type(
+    return render_root_model(
         py_type,
         content=" | ".join(py_type.type_hint for py_type in py_type.inner_py_types),
     )


### PR DESCRIPTION
<!-- This template is managed by Pulumi!

## Pre-flight checklist

- [ ] reviewed own code
- [ ] tests are green
- [ ] linter is happy
-->

## Reviewer

- [ ] for your information
- [ ] process and function, acceptance criteria
- [ ] implementation (code design, correctness, formatting)
  - [ ] unit tests are implemented
  - [ ] E2E tests are implemented, if reasonable
- [ ] testing
  - [ ] checklist of test cases for manual testing is created
  - [ ] all test cases are passed successfully
  - [ ] invariants are checked (what should stay the same or **not** be affected by the changes)

## Description

The example is copied from Softfair customer spec:
```yaml
paths:
  /dokument/get/data:
    post:
      operationId: GetDokumente
      requestBody:
        description: Liste der auszulesenden Dokumente
        content:
          application/json:
            schema:
              $ref: '#/components/schemas/DokumentIDs'
      responses:
        '200':
          description: Successful response

components:
  schemas:
    DokumentIDs:
      type: array
      items:
        type: integer
        format: int32
```
`spec2sdk` generates a model `DokumentIDs: TypeAlias = list[int]` that will be used as a type for parameter in the `get_dokumente` method:
![image](https://github.com/user-attachments/assets/cbb4be00-cc91-4191-b71d-26c883443585)
But the type of the field doesn't meet HTTPClient requirements for the `body` field. It must be a `BaseModel` to be serializable. This PR makes simple types serializable. New model will be `DokumentIDs = RootModel[list[int]]` and [can be serialized](https://docs.pydantic.dev/latest/concepts/models/#rootmodel-and-custom-root-types).