### PR TITLE
ci(actions): remove mergealot ssh key

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,6 @@ jobs:
           show-progress: false
 
       - uses: moneymeets/action-setup-python-poetry@master
-        with:
-          ssh_key: ${{ secrets.MERGEALOT_SSH_KEY }}
 
       - uses: moneymeets/moneymeets-composite-actions/lint-python@master
 


### PR DESCRIPTION
<!-- This template is managed by Pulumi!

## Pre-flight checklist

- [ ] reviewed own code
- [ ] tests are green
- [ ] linter is happy
-->

## Reviewer

- [ ] for your information
- [ ] process and function, acceptance criteria
- [ ] implementation (code design, correctness, formatting)
  - [ ] unit tests are implemented
  - [ ] E2E tests are implemented, if reasonable
- [ ] testing
  - [ ] checklist of test cases for manual testing is created
  - [ ] all test cases are passed successfully
  - [ ] invariants are checked (what should stay the same or **not** be affected by the changes)

## Description

@catcombo was wondering if we can remove the mergealot ssh key in https://github.com/moneymeets/moneymeets-pulumi/pull/707. I also don't see a reason why we would need it. 
