### PR TITLE
Feature/publish python package

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,23 @@
+name: Publish
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  publish-package:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: moneymeets/action-setup-python-poetry@master
+
+      - name: Publish package
+        run: |
+          sed -i -e "s/1+SNAPSHOT/0.$(date +"%Y%m%d%H%M")/" pyproject.toml
+          git rev-parse HEAD > VERSION.txt
+          poetry publish --build
+        env:
+          POETRY_PYPI_TOKEN_PYPI: ${{ secrets.POETRY_PYPI_TOKEN_PYPI }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,22 @@
 [tool.poetry]
 name = "spec2sdk"
-version = "0.1.0"
+version = "1.1+SNAPSHOT"
 description = "Generate Pydantic models and API client code from OpenAPI 3.x specifications"
 authors = ["moneymeets <service@moneymeets.com>"]
 readme = "README.md"
 repository = "https://github.com/moneymeets/spec2sdk"
 packages = [
     { include="spec2sdk" },
+]
+keywords = ["openapi", "pydantic", "code-generator", "openapi-codegen"]
+license = "MIT"
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Intended Audience :: Developers",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+    "License :: OSI Approved :: MIT License",
 ]
 
 [tool.poetry.dependencies]


### PR DESCRIPTION
I prepared changes in `pyproject.toml` and CI for publishing `spec2sdk` to PyPI as we did for https://github.com/moneymeets/youtrack-sdk/ My only concerns are PyPI credentials. PyPI changed requirements and I had to switch to authorization token instead of basic authorization when I deployed one of my personal package in the last time. Probably, we should switch to authorization token here and in the YouTrack SDK as well. Can you login to PyPI and check if my statement is true? If this is true, we can use `POETRY_PYPI_TOKEN_PYPI` instead of `POETRY_HTTP_BASIC_PYPI_*` in the `publish.yml`.