### PR TITLE
feat(spec2sdk): add URL references resolver

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 from pathlib import Path
 from spec2sdk.main import generate
 
-generate(input_file=Path("path/to/api.yml"), output_dir=Path("path/to/output-dir/"))
+generate(url=Path("path/to/api.yml").absolute().as_uri(), output_dir=Path("path/to/output-dir/"))
 ```
 
 # Open API specification requirements
@@ -160,7 +160,7 @@ def render_email_field(py_type: EmailPythonType) -> TypeRenderer:
 
 
 if __name__ == "__main__":
-    generate(input_file=Path("api.yml"), output_dir=Path("output"))
+    generate(url=Path("api.yml").absolute().as_uri(), output_dir=Path("output"))
 ```
 
 ## Output

--- a/tests/parsers/resolver/test_data/schema_cache/api.yml
+++ b/tests/parsers/resolver/test_data/schema_cache/api.yml
@@ -1,0 +1,32 @@
+openapi: 3.0.0
+
+info:
+  title: Example API
+  version: '1.0'
+
+paths:
+  /users:
+    get:
+      operationId: getUsers
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: 'definitions/users.yml#/components/schemas/User'
+
+  /userGroups:
+    get:
+      operationId: getUserGroups
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: './definitions/users.yml#/components/schemas/UserGroup'

--- a/tests/parsers/resolver/test_data/schema_cache/definitions/users.yml
+++ b/tests/parsers/resolver/test_data/schema_cache/definitions/users.yml
@@ -1,0 +1,25 @@
+components:
+  schemas:
+    User:
+      type: object
+      properties:
+        name:
+          type: string
+        email:
+          type: string
+
+    UserGroup:
+      type: object
+      properties:
+        name:
+          type: string
+        permissions:
+          type: array
+          items:
+            $ref: 'users.yml#/components/schemas/Permission'
+
+    Permission:
+      type: object
+      properties:
+        name:
+          type: string

--- a/tests/parsers/resolver/test_data/url_references/expected_output/schema.json
+++ b/tests/parsers/resolver/test_data/url_references/expected_output/schema.json
@@ -1,0 +1,60 @@
+{
+  "info": {
+    "title": "Example API",
+    "version": "1.0"
+  },
+  "openapi": "3.0.0",
+  "paths": {
+    "/comment{commentId}": {
+      "get": {
+        "operationId": "getComment",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "commentId",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            },
+            "x-schema-name": "CommentId"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "author": {
+                      "properties": {
+                        "city": {
+                          "maxLength": 50,
+                          "type": "string",
+                          "x-schema-name": "City"
+                        },
+                        "email": {
+                          "type": "string"
+                        },
+                        "name": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "x-schema-name": "User"
+                    },
+                    "text": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "x-schema-name": "Comment"
+                }
+              }
+            },
+            "description": "Successful response"
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/parsers/resolver/test_data/url_references/input/api.yml
+++ b/tests/parsers/resolver/test_data/url_references/input/api.yml
@@ -1,0 +1,19 @@
+openapi: 3.0.0
+
+info:
+  title: Example API
+  version: '1.0'
+
+paths:
+  /comment{commentId}:
+    get:
+      operationId: getComment
+      parameters:
+        - $ref: 'http://localhost/definitions/parameters.yml#/components/parameters/CommentId'
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: 'http://localhost/definitions/schemas.yml#/components/schemas/Comment'

--- a/tests/parsers/resolver/test_data/url_references/input/definitions/parameters.yml
+++ b/tests/parsers/resolver/test_data/url_references/input/definitions/parameters.yml
@@ -1,0 +1,8 @@
+components:
+  parameters:
+    CommentId:
+      name: commentId
+      in: path
+      required: true
+      schema:
+        type: integer

--- a/tests/parsers/resolver/test_data/url_references/input/definitions/schemas.yml
+++ b/tests/parsers/resolver/test_data/url_references/input/definitions/schemas.yml
@@ -1,0 +1,9 @@
+components:
+  schemas:
+    Comment:
+      type: object
+      properties:
+        text:
+          type: string
+        author:
+          $ref: 'users/user.yml#/components/schemas/User'

--- a/tests/parsers/resolver/test_data/url_references/input/definitions/users/location.yml
+++ b/tests/parsers/resolver/test_data/url_references/input/definitions/users/location.yml
@@ -1,0 +1,5 @@
+components:
+  schemas:
+    City:
+      type: string
+      maxLength: 50

--- a/tests/parsers/resolver/test_data/url_references/input/definitions/users/user.yml
+++ b/tests/parsers/resolver/test_data/url_references/input/definitions/users/user.yml
@@ -1,0 +1,11 @@
+components:
+  schemas:
+    User:
+      type: object
+      properties:
+        name:
+          type: string
+        email:
+          type: string
+        city:
+          $ref: './location.yml#/components/schemas/City'


### PR DESCRIPTION
# New feature

1. Adds support for URLs in the OpenAPI specification. Example:
```yaml
paths:
  /comment{commentId}:
    get:
      operationId: getComment
      parameters:
        - $ref: 'https://example.com/api/parameters.yml#/components/parameters/CommentId'
      responses:
        '200':
          description: Successful response
          content:
            application/json:
              schema:
                $ref: 'https://example.com/api/schemas.yml#/components/schemas/Comment'
```
2. Adds tests for the URL resolver and resolver schema caching.

# Backward incompatible changes

1. `generate` function signature has been changed. `input_file` parameter has been renamed to `url` and accepts only URLs. For the local specification `Path` has a special method to convert file path to URI: `generate(url=Path("path/to/api.yml").absolute().as_uri(), output_dir=...)`
2. CLI command `spec2sdk` has now `--input` argument instead of `--input-file`. `--input` accepts either file path (including related path) or URL.