### PR TITLE
feat(parsers): ignore sibling elements of $ref according to OpenAPI 3.0 specification

### DIFF
--- a/spec2sdk/openapi/resolver.py
+++ b/spec2sdk/openapi/resolver.py
@@ -68,13 +68,14 @@ class ResolvingParser:
 
             return self._resolved_references[reference_id]
 
-        return {
-            new_key: new_value
-            for key, value in schema.items()
-            for new_key, new_value in (
-                resolve_reference(value) if key == "$ref" else {key: resolve_value(value)}
-            ).items()
-        }
+        # Object containing $ref cannot be extended with additional properties
+        # and any properties added SHALL be ignored.
+        # https://spec.openapis.org/oas/v3.0.0.html#reference-object
+        return (
+            resolve_reference(schema["$ref"])
+            if "$ref" in schema
+            else {key: resolve_value(value) for key, value in schema.items()}
+        )
 
     def parse(self, url: str) -> dict:
         schema_loader = SchemaLoader(schema_url=url)

--- a/tests/parsers/resolver/test_data/references_with_siblings/expected_output/schema.json
+++ b/tests/parsers/resolver/test_data/references_with_siblings/expected_output/schema.json
@@ -1,0 +1,46 @@
+{
+  "components": {
+    "schemas": {
+      "HealthStatus": {
+        "description": "Schema description",
+        "properties": {
+          "status": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      }
+    }
+  },
+  "info": {
+    "title": "Example API",
+    "version": "1.0"
+  },
+  "openapi": "3.0.0",
+  "paths": {
+    "/health": {
+      "get": {
+        "operationId": "healthCheck",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Schema description",
+                  "properties": {
+                    "status": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "x-schema-name": "HealthStatus"
+                }
+              }
+            },
+            "description": "Successful response"
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/parsers/resolver/test_data/references_with_siblings/input/api.yml
+++ b/tests/parsers/resolver/test_data/references_with_siblings/input/api.yml
@@ -1,0 +1,28 @@
+openapi: 3.0.0
+
+info:
+  title: Example API
+  version: '1.0'
+
+paths:
+  /health:
+    get:
+      operationId: healthCheck
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HealthStatus'
+                description: Response content description
+                nullable: true
+
+components:
+  schemas:
+    HealthStatus:
+      description: Schema description
+      type: object
+      properties:
+        status:
+          type: string

--- a/tests/parsers/resolver/test_resolver.py
+++ b/tests/parsers/resolver/test_resolver.py
@@ -12,7 +12,7 @@ from spec2sdk.openapi.resolver import ResolvingParser
 TEST_DATA_DIR = Path(__file__).parent / "test_data"
 
 
-@pytest.mark.parametrize("test_data_name", ("local_references", "remote_references"))
+@pytest.mark.parametrize("test_data_name", ("local_references", "remote_references", "references_with_siblings"))
 def test_resolve_references(test_data_name: str):
     data_dir = TEST_DATA_DIR / test_data_name
     spec_path = data_dir / "input" / "api.yml"


### PR DESCRIPTION
According to [OpenAPI 3.0 specification](https://spec.openapis.org/oas/v3.0.0.html#reference-object) object containing `$ref` cannot be extended with additional properties and any properties added SHALL be ignored. We already have problems in our auto-generated code when `description` from object containing `$ref` overrides schema description.

In [OpenAPI 3.1](https://spec.openapis.org/oas/v3.1.0.html#reference-object) `summary` and `description` are allowed, but I would like to concentrate on one spec version and extend code later if needed. Because right now it'll take more efforts to implement different behavior based on the spec version. Spec version should be also correctly handled in other parts of the code. Since our specs are 3.0 it shouldn't be a problem for now.