### PR TITLE
fix(spec2sdk): add a trailing space inside a string after spliting long field description

### DIFF
--- a/spec2sdk/models/entities.py
+++ b/spec2sdk/models/entities.py
@@ -205,7 +205,7 @@ class ModelType(PythonType):
 
     def render(self) -> str:
         def split_long_lines(s: str) -> str:
-            return '"' + '""'.join(line.replace('"', r"\"") for line in textwrap.wrap(s, width=80)) + '"'
+            return '"' + ' ""'.join(line.replace('"', r"\"") for line in textwrap.wrap(s, width=80)) + '"'
 
         def create_model_field_view(field: ModelField) -> ModelFieldView:
             attrs = []


### PR DESCRIPTION
There is an issue when splitting long text in the field's description.
```
description="Adressinformationen zum Inhaber einer Bankverbindung wenn dieser nicht gleich" "des User ist",
```
String is split correctly, but there is a missing trailing space at the end of all strings except last one that causes string to be concatenated incorrectly.
```
Adressinformationen zum Inhaber einer Bankverbindung wenn dieser nicht gleichdes User ist
```