### PR TITLE
Feature/improve type annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,28 +126,23 @@ components:
 
 ```python
 from pathlib import Path
-from typing import Sequence
 
 from spec2sdk.openapi.entities import DataType, StringDataType
+from spec2sdk.models.annotations import TypeAnnotation
 from spec2sdk.models.converters import converters, convert_common_fields
-from spec2sdk.models.entities import PythonType
+from spec2sdk.models.entities import SimpleType
 from spec2sdk.models.imports import Import
 from spec2sdk.main import generate
 
 
-class EmailType(PythonType):
+class EmailType(SimpleType):
     @property
-    def type_hint(self) -> str:
-        return self.name or "EmailStr"
-
-    @property
-    def imports(self) -> Sequence[Import]:
-        return (
-            Import(name="EmailStr", package="pydantic"),
+    def type_definition(self) -> TypeAnnotation:
+        return TypeAnnotation(
+            type_hint="EmailStr",
+            type_imports=(Import(name="EmailStr", package="pydantic"),),
+            constraints=(),
         )
-
-    def render(self) -> str:
-        return f"type {self.name} = EmailStr" if self.name else ""
 
 
 def is_email_format(data_type: DataType) -> bool:

--- a/spec2sdk/client/views.py
+++ b/spec2sdk/client/views.py
@@ -6,7 +6,16 @@ from typing import Sequence
 from spec2sdk.base import Model
 from spec2sdk.models.converters import converters
 from spec2sdk.models.identifiers import make_variable_name
-from spec2sdk.openapi.entities import Endpoint, Parameter, ParameterLocation, Path, RequestBody, Response
+from spec2sdk.openapi.entities import (
+    Endpoint,
+    NullDataType,
+    OneOfDataType,
+    Parameter,
+    ParameterLocation,
+    Path,
+    RequestBody,
+    Response,
+)
 
 
 def wordwrap(s: str, width: int) -> str:
@@ -44,7 +53,25 @@ class ParameterView:
 
     @property
     def type_hint(self) -> str:
-        return converters.convert(self.__parameter.data_type).type_hint
+        return converters.convert(
+            self.__parameter.data_type
+            if self.required
+            else OneOfDataType(
+                name=None,
+                description=None,
+                default_value=None,
+                enumerators=None,
+                data_types=(
+                    self.__parameter.data_type,
+                    NullDataType(
+                        name=None,
+                        description=None,
+                        default_value=None,
+                        enumerators=None,
+                    ),
+                ),
+            ),
+        ).type_hint
 
     @property
     def required(self) -> bool:

--- a/spec2sdk/models/annotations.py
+++ b/spec2sdk/models/annotations.py
@@ -1,0 +1,52 @@
+from itertools import groupby
+from typing import Any, Sequence
+
+from spec2sdk.base import Model
+from spec2sdk.models.imports import Import
+
+
+class TypeConstraintParameter(Model):
+    name: str
+    value: Any
+
+
+class TypeConstraint(Model):
+    name: str
+    parameters: Sequence[TypeConstraintParameter]
+    imports: Sequence[Import]
+
+
+class TypeAnnotation(Model):
+    type_hint: str
+    type_imports: Sequence[Import]
+    constraints: Sequence[TypeConstraint]
+
+    @property
+    def imports(self) -> Sequence[Import]:
+        return (
+            *(
+                (
+                    Import(name="Annotated", package="typing"),
+                    *(import_ for constraint in self.constraints for import_ in constraint.imports),
+                )
+                if self.constraints
+                else ()
+            ),
+            *self.type_imports,
+        )
+
+    def render(self) -> str:
+        constraints = ", ".join(
+            (
+                f"{annotation_name}("
+                + ", ".join(
+                    f"{parameter.name}={parameter.value}"
+                    for annotation in annotation_group
+                    for parameter in annotation.parameters
+                )
+                + ")"
+            )
+            for annotation_name, annotation_group in groupby(self.constraints, lambda a: a.name)
+        )
+
+        return f"Annotated[{self.type_hint}, {constraints}]" if constraints else self.type_hint

--- a/spec2sdk/models/converters.py
+++ b/spec2sdk/models/converters.py
@@ -99,7 +99,6 @@ def convert_object(data_type: ObjectDataType) -> ModelType:
             ModelField(
                 name=make_variable_name(prop.name),
                 alias=prop.name,
-                type_hint=inner_py_type.type_hint,
                 description=prop.data_type.description if inner_py_type.name is None else None,
                 default_value=inner_py_type.default_value,
                 is_required=prop.is_required,

--- a/spec2sdk/models/entities.py
+++ b/spec2sdk/models/entities.py
@@ -1,25 +1,42 @@
 import textwrap
-from abc import abstractmethod
+from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import Any, Sequence
 
 from spec2sdk.base import Model
+from spec2sdk.models.annotations import TypeAnnotation, TypeConstraint, TypeConstraintParameter
 from spec2sdk.models.imports import Import
 from spec2sdk.templating import create_jinja_environment
 
 
-class PythonType(Model):
+class PythonType(Model, ABC):
     name: str | None
     description: str | None
     default_value: Any
 
     @property
-    @abstractmethod
-    def type_hint(self) -> str: ...
+    def dependency_types(self) -> Sequence["PythonType"]:
+        return ()
 
     @property
     @abstractmethod
-    def imports(self) -> Sequence[Import]: ...
+    def type_definition(self) -> TypeAnnotation: ...
+
+    @property
+    def type_annotation(self) -> TypeAnnotation:
+        return (
+            TypeAnnotation(type_hint=self.name, type_imports=self.type_definition.type_imports, constraints=())
+            if self.name
+            else self.type_definition
+        )
+
+    @property
+    def type_hint(self) -> str:
+        return self.type_annotation.render()
+
+    @property
+    def imports(self) -> Sequence[Import]:
+        return self.type_definition.imports
 
     @abstractmethod
     def render(self) -> str:
@@ -28,24 +45,22 @@ class PythonType(Model):
         """
         ...
 
-    @property
-    def dependency_types(self) -> Sequence["PythonType"]:
-        return ()
+
+class SimpleType(PythonType, ABC):
+    def render(self) -> str:
+        return f"type {self.name} = {self.type_definition.render()}"
 
 
-class LiteralType(PythonType):
+class LiteralType(SimpleType):
     literals: Sequence[Any]
 
     @property
-    def type_hint(self) -> str:
-        return "Literal[" + ",".join(repr(literal) for literal in self.literals) + "]"
-
-    @property
-    def imports(self) -> Sequence[Import]:
-        return (Import(name="Literal", package="typing"),)
-
-    def render(self) -> str:
-        return f"type {self.name} = {self.type_hint}"
+    def type_definition(self) -> TypeAnnotation:
+        return TypeAnnotation(
+            type_hint="Literal[" + ",".join(repr(literal) for literal in self.literals) + "]",
+            type_imports=(Import(name="Literal", package="typing"),),
+            constraints=(),
+        )
 
 
 class EnumMember(Model):
@@ -63,12 +78,12 @@ class EnumType(PythonType):
     default_value: EnumMember | None
 
     @property
-    def type_hint(self) -> str:
-        return self.name
-
-    @property
-    def imports(self) -> Sequence[Import]:
-        return (Import(name="Enum", package="enum"),)
+    def type_definition(self) -> TypeAnnotation:
+        return TypeAnnotation(
+            type_hint=self.name,
+            type_imports=(Import(name="Enum", package="enum"),),
+            constraints=(),
+        )
 
     def render(self) -> str:
         return (
@@ -84,8 +99,12 @@ class EnumType(PythonType):
 
 class StrEnumType(EnumType):
     @property
-    def imports(self) -> Sequence[Import]:
-        return (Import(name="StrEnum", package="enum"),)
+    def type_definition(self) -> TypeAnnotation:
+        return TypeAnnotation(
+            type_hint=self.name,
+            type_imports=(Import(name="StrEnum", package="enum"),),
+            constraints=(),
+        )
 
     def render(self) -> str:
         return (
@@ -99,7 +118,7 @@ class StrEnumType(EnumType):
         )
 
 
-class NumericType[T](PythonType):
+class NumericType[T](SimpleType):
     default_value: T | None
     minimum: T | None
     maximum: T | None
@@ -112,8 +131,8 @@ class NumericType[T](PythonType):
     def type_name(self) -> str: ...
 
     @property
-    def _is_constrained_type(self) -> bool:
-        return (
+    def type_definition(self) -> TypeAnnotation:
+        constrained_type = (
             (self.minimum is not None)
             or (self.maximum is not None)
             or (self.exclusive_minimum is not None)
@@ -121,39 +140,45 @@ class NumericType[T](PythonType):
             or (self.multiple_of is not None)
         )
 
-    @property
-    def _type_annotation(self) -> str:
-        if self._is_constrained_type:
-            constraints = ",".join(
-                (
-                    *((f"ge={self.minimum}",) if self.minimum is not None else ()),
-                    *((f"le={self.maximum}",) if self.maximum is not None else ()),
-                    *((f"gt={self.exclusive_minimum}",) if self.exclusive_minimum is not None else ()),
-                    *((f"lt={self.exclusive_maximum}",) if self.exclusive_maximum is not None else ()),
-                    *((f"multiple_of={self.multiple_of}",) if self.multiple_of is not None else ()),
+        constraints = (
+            (
+                TypeConstraint(
+                    name="Field",
+                    parameters=(
+                        *(
+                            (TypeConstraintParameter(name="ge", value=self.minimum),)
+                            if self.minimum is not None
+                            else ()
+                        ),
+                        *(
+                            (TypeConstraintParameter(name="le", value=self.maximum),)
+                            if self.maximum is not None
+                            else ()
+                        ),
+                        *(
+                            (TypeConstraintParameter(name="gt", value=self.exclusive_minimum),)
+                            if self.exclusive_minimum is not None
+                            else ()
+                        ),
+                        *(
+                            (TypeConstraintParameter(name="lt", value=self.exclusive_maximum),)
+                            if self.exclusive_maximum is not None
+                            else ()
+                        ),
+                        *(
+                            (TypeConstraintParameter(name="multiple_of", value=self.multiple_of),)
+                            if self.multiple_of is not None
+                            else ()
+                        ),
+                    ),
+                    imports=(Import(name="Field", package="pydantic"),),
                 ),
             )
-            return f"Annotated[{self.type_name}, Field({constraints})]"
-        else:
-            return self.type_name
-
-    @property
-    def type_hint(self) -> str:
-        return self.name or self._type_annotation
-
-    @property
-    def imports(self) -> Sequence[Import]:
-        return (
-            (
-                Import(name="Annotated", package="typing"),
-                Import(name="Field", package="pydantic"),
-            )
-            if self._is_constrained_type
+            if constrained_type
             else ()
         )
 
-    def render(self) -> str:
-        return f"type {self.name} = {self._type_annotation}"
+        return TypeAnnotation(type_hint=self.type_name, type_imports=(), constraints=constraints)
 
 
 class IntegerType(NumericType[int]):
@@ -168,81 +193,63 @@ class FloatType(NumericType[float]):
         return "float"
 
 
-class BooleanType(PythonType):
+class BooleanType(SimpleType):
     default_value: bool | None
 
     @property
-    def type_hint(self) -> str:
-        return self.name or "bool"
-
-    @property
-    def imports(self) -> Sequence[Import]:
-        return ()
-
-    def render(self) -> str:
-        return f"type {self.name} = bool"
+    def type_definition(self) -> TypeAnnotation:
+        return TypeAnnotation(type_hint="bool", type_imports=(), constraints=())
 
 
-class StringType(PythonType):
+class StringType(SimpleType):
     default_value: str | None
     pattern: str | None
     min_length: int | None
     max_length: int | None
 
     @property
-    def _is_constrained_type(self) -> bool:
-        return bool(self.pattern) or (self.min_length is not None) or (self.max_length is not None)
-
-    @property
-    def _type_annotation(self) -> str:
-        if self._is_constrained_type:
-            constraints = ",".join(
-                (
-                    *((f'pattern=r"{self.pattern}"',) if self.pattern else ()),
-                    *((f"min_length={self.min_length}",) if self.min_length is not None else ()),
-                    *((f"max_length={self.max_length}",) if self.max_length is not None else ()),
+    def type_definition(self) -> TypeAnnotation:
+        constrained_type = bool(self.pattern) or (self.min_length is not None) or (self.max_length is not None)
+        constraints = (
+            (
+                TypeConstraint(
+                    name="StringConstraints",
+                    parameters=(
+                        *(
+                            (TypeConstraintParameter(name="pattern", value=f'r"{self.pattern}"'),)
+                            if self.pattern is not None
+                            else ()
+                        ),
+                        *(
+                            (TypeConstraintParameter(name="min_length", value=self.min_length),)
+                            if self.min_length is not None
+                            else ()
+                        ),
+                        *(
+                            (TypeConstraintParameter(name="max_length", value=self.max_length),)
+                            if self.max_length is not None
+                            else ()
+                        ),
+                    ),
+                    imports=(Import(name="StringConstraints", package="pydantic"),),
                 ),
             )
-            return f"Annotated[str, StringConstraints({constraints})]"
-        else:
-            return "str"
-
-    @property
-    def type_hint(self) -> str:
-        return self.name or self._type_annotation
-
-    @property
-    def imports(self) -> Sequence[Import]:
-        return (
-            (
-                Import(name="Annotated", package="typing"),
-                Import(name="StringConstraints", package="pydantic"),
-            )
-            if self._is_constrained_type
+            if constrained_type
             else ()
         )
 
-    def render(self) -> str:
-        return f"type {self.name} = {self._type_annotation}"
+        return TypeAnnotation(type_hint="str", type_imports=(), constraints=constraints)
 
 
-class BinaryType(PythonType):
+class BinaryType(SimpleType):
     @property
-    def type_hint(self) -> str:
-        return self.name or "bytes"
-
-    @property
-    def imports(self) -> Sequence[Import]:
-        return ()
-
-    def render(self) -> str:
-        return f"type {self.name} = bytes"
+    def type_definition(self) -> TypeAnnotation:
+        return TypeAnnotation(type_hint="bytes", type_imports=(), constraints=())
 
 
 class ModelField(Model):
     name: str
     alias: str
-    type_hint: str
     description: str | None
     default_value: Any
     is_required: bool
@@ -251,7 +258,7 @@ class ModelField(Model):
 
 class ModelFieldView(Model):
     name: str
-    type_definition: str
+    type_hint: str
 
 
 class ModelType(PythonType):
@@ -264,37 +271,52 @@ class ModelType(PythonType):
         return *tuple(field.inner_py_type for field in self.fields), *self.base_models
 
     @property
-    def type_hint(self) -> str:
-        return self.name
-
-    @property
-    def imports(self) -> Sequence[Import]:
-        return (
-            *((Import(name="Field", package="pydantic"),) if len(self.fields) > 0 else ()),
-            *((Import(name="ConfigDict", package="pydantic"),) if self.arbitrary_fields_allowed else ()),
+    def type_definition(self) -> TypeAnnotation:
+        return TypeAnnotation(
+            type_hint=self.name,
+            type_imports=(
+                *(import_ for field in self.fields for import_ in self.create_field_annotation(field).imports),
+                *((Import(name="ConfigDict", package="pydantic"),) if self.arbitrary_fields_allowed else ()),
+            ),
+            constraints=(),
         )
 
-    def render(self) -> str:
+    def create_field_annotation(self, field: ModelField) -> TypeAnnotation:
         def split_long_lines(s: str) -> str:
             return '"' + ' ""'.join(line.replace('"', r"\"") for line in textwrap.wrap(s, width=80)) + '"'
 
-        def create_model_field_view(field: ModelField) -> ModelFieldView:
-            attrs = []
+        field_constraints = (
+            *(
+                (TypeConstraintParameter(name="default", value=repr(field.default_value)),)
+                if field.default_value is not None or not field.is_required
+                else ()
+            ),
+            *((TypeConstraintParameter(name="alias", value=repr(field.alias)),) if field.name != field.alias else ()),
+            *(
+                (TypeConstraintParameter(name="description", value=split_long_lines(field.description)),)
+                if field.description
+                else ()
+            ),
+        )
 
-            if field.default_value is not None or not field.is_required:
-                attrs.append(f"default={repr(field.default_value)}")
-
-            if field.name != field.alias:
-                attrs.append(f'alias="{field.alias}"')
-
-            if field.description:
-                attrs.append(f"description={split_long_lines(field.description)}")
-
-            return ModelFieldView(
-                name=field.name,
-                type_definition=field.type_hint + (f" = Field({','.join(attrs)})" if attrs else ""),
+        return (
+            field.inner_py_type.type_annotation.model_copy(
+                update={
+                    "constraints": (
+                        *field.inner_py_type.type_annotation.constraints,
+                        TypeConstraint(
+                            name="Field",
+                            parameters=field_constraints,
+                            imports=((Import(name="Field", package="pydantic"),)),
+                        ),
+                    ),
+                },
             )
+            if field_constraints
+            else field.inner_py_type.type_annotation
+        )
 
+    def render(self) -> str:
         base_class_names = tuple(base_model.name for base_model in self.base_models if base_model.name)
 
         return (
@@ -303,77 +325,64 @@ class ModelType(PythonType):
             .render(
                 base_class_name=", ".join(base_class_names) if base_class_names else "Model",
                 model_type=self,
-                fields=tuple(map(create_model_field_view, self.fields)),
+                fields=tuple(
+                    ModelFieldView(name=field.name, type_hint=self.create_field_annotation(field).render())
+                    for field in self.fields
+                ),
                 arbitrary_fields_allowed=self.arbitrary_fields_allowed,
             )
         )
 
 
-class NoneType(PythonType):
+class NoneType(SimpleType):
     @property
-    def dependency_types(self) -> Sequence[PythonType]:
-        return ()
-
-    @property
-    def type_hint(self) -> str:
-        return self.name or "None"
-
-    @property
-    def imports(self) -> Sequence[Import]:
-        return ()
-
-    def render(self) -> str:
-        return f"type {self.name} = None"
+    def type_definition(self) -> TypeAnnotation:
+        return TypeAnnotation(type_hint="None", type_imports=(), constraints=())
 
 
-class ListType(PythonType):
+class ListType(SimpleType):
     inner_py_type: PythonType
     min_items: int | None
     max_items: int | None
-
-    @property
-    def _is_constrained_type(self) -> bool:
-        return (self.min_items is not None) or (self.max_items is not None)
-
-    @property
-    def _type_annotation(self) -> str:
-        type_name = f"list[{self.inner_py_type.type_hint}]"
-
-        if self._is_constrained_type:
-            constraints = ",".join(
-                (
-                    *((f"min_length={self.min_items}",) if self.min_items is not None else ()),
-                    *((f"max_length={self.max_items}",) if self.max_items is not None else ()),
-                ),
-            )
-            return f"Annotated[{type_name}, Field({constraints})]"
-        else:
-            return type_name
 
     @property
     def dependency_types(self) -> Sequence[PythonType]:
         return (self.inner_py_type,)
 
     @property
-    def type_hint(self) -> str:
-        return self.name or self._type_annotation
-
-    @property
-    def imports(self) -> Sequence[Import]:
-        return (
+    def type_definition(self) -> TypeAnnotation:
+        constrained_type = (self.min_items is not None) or (self.max_items is not None)
+        constraints = (
             (
-                Import(name="Annotated", package="typing"),
-                Import(name="Field", package="pydantic"),
+                TypeConstraint(
+                    name="Field",
+                    parameters=(
+                        *(
+                            (TypeConstraintParameter(name="min_length", value=self.min_items),)
+                            if self.min_items is not None
+                            else ()
+                        ),
+                        *(
+                            (TypeConstraintParameter(name="max_length", value=self.max_items),)
+                            if self.max_items is not None
+                            else ()
+                        ),
+                    ),
+                    imports=(Import(name="Field", package="pydantic"),),
+                ),
             )
-            if self._is_constrained_type
+            if constrained_type
             else ()
         )
 
-    def render(self) -> str:
-        return f"type {self.name} = {self._type_annotation}"
+        return TypeAnnotation(
+            type_hint=f"list[{self.inner_py_type.type_hint}]",
+            type_imports=(),
+            constraints=constraints,
+        )
 
 
-class UnionType(PythonType):
+class UnionType(SimpleType):
     inner_py_types: Sequence[PythonType]
 
     @property
@@ -381,13 +390,9 @@ class UnionType(PythonType):
         return self.inner_py_types
 
     @property
-    def type_hint(self) -> str:
-        return self.name or " | ".join(py_type.type_hint for py_type in self.inner_py_types)
-
-    @property
-    def imports(self) -> Sequence[Import]:
-        return ()
-
-    def render(self) -> str:
-        root_type = " | ".join(py_type.type_hint for py_type in self.inner_py_types)
-        return f"type {self.name} = {root_type}"
+    def type_definition(self) -> TypeAnnotation:
+        return TypeAnnotation(
+            type_hint=" | ".join(py_type.type_hint for py_type in self.inner_py_types),
+            type_imports=(),
+            constraints=(),
+        )

--- a/spec2sdk/models/templates/model.j2
+++ b/spec2sdk/models/templates/model.j2
@@ -5,7 +5,7 @@ class {{ model_type.name }}({{ base_class_name }}):
     """
     {% endif %}
     {% for field in fields -%}
-        {{ field.name }}: {{ field.type_definition }}
+        {{ field.name }}: {{ field.type_hint }}
     {% endfor %}
     {% if arbitrary_fields_allowed %}model_config = ConfigDict(extra="allow"){% endif %}
     {% if not arbitrary_fields_allowed and not fields %}pass{% endif %}


### PR DESCRIPTION
# Annotate optional parameters correctly

```yaml
page_size:
  name: page_size
  in: query
  required: false
  schema:
    type: integer
```

## master branch

```python
def search(self, *, page_size: int = None) -> ...:
```

## This PR

```python
def search(self, *, page_size: int | None = None) -> ...:
```

# Use type annotations instead of type hint for better type annotation

```yaml
schemas:
  User:
    type: object
    description: Schema description
    properties:
      name:
        type: string
      email:
        type: string
        format: email
      age:
        type: integer
        minimum: 0
        description: User age
      cityOfBirth:
        type: string
        minLength: 5
    required:
      - name
      - age
      - cityOfBirth
```

## master branch

```python
class User(Model):
    """
    Schema description
    """

    name: str
    email: EmailStr | None = Field(default=None)
    age: Annotated[int, Field(ge=0)] = Field(description="User age")
    city_of_birth: Annotated[str, StringConstraints(min_length=5)] = Field(alias="cityOfBirth")
```

## This PR

```python
class User(Model):
    """
    Schema description
    """

    name: str
    email: Annotated[EmailStr | None, Field(default=None)]
    age: Annotated[int, Field(ge=0, description="User age")]
    city_of_birth: Annotated[str, StringConstraints(min_length=5), Field(alias="cityOfBirth")]
```
