### PR TITLE
feat(spec2sdk): remove description and default value fields from base types

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ from pathlib import Path
 
 from spec2sdk.openapi.entities import DataType, StringDataType
 from spec2sdk.models.annotations import TypeAnnotation
-from spec2sdk.models.converters import converters, convert_common_fields
+from spec2sdk.models.converters import converters, make_type_class_name
 from spec2sdk.models.entities import SimpleType
 from spec2sdk.models.imports import Import
 from spec2sdk.main import generate
@@ -151,7 +151,7 @@ def is_email_format(data_type: DataType) -> bool:
 
 @converters.register(predicate=is_email_format)
 def convert_email_field(data_type: StringDataType) -> EmailType:
-    return EmailType(**convert_common_fields(data_type))
+    return EmailType(name=make_type_class_name(data_type))
 
 
 if __name__ == "__main__":

--- a/spec2sdk/models/entities.py
+++ b/spec2sdk/models/entities.py
@@ -12,8 +12,6 @@ from spec2sdk.templating import create_jinja_environment
 
 class PythonType(Model, ABC):
     name: str | None
-    description: str | None
-    default_value: Any
 
     @property
     def dependency_types(self) -> Sequence["PythonType"]:
@@ -76,7 +74,6 @@ class EnumMemberView(Model):
 
 class EnumType(PythonType):
     members: Sequence[EnumMember]
-    default_value: EnumMember | None
 
     @property
     def type_definition(self) -> TypeAnnotation:
@@ -120,7 +117,6 @@ class StrEnumType(EnumType):
 
 
 class NumericType[T](SimpleType):
-    default_value: T | None
     minimum: T | None
     maximum: T | None
     exclusive_minimum: T | None
@@ -195,15 +191,12 @@ class FloatType(NumericType[float]):
 
 
 class BooleanType(SimpleType):
-    default_value: bool | None
-
     @property
     def type_definition(self) -> TypeAnnotation:
         return TypeAnnotation(type_hint="bool", type_imports=(), constraints=())
 
 
 class StringType(SimpleType):
-    default_value: str | None
     pattern: str | None
     min_length: int | None
     max_length: int | None
@@ -264,6 +257,7 @@ class ModelFieldView(Model):
 
 class ModelType(PythonType):
     base_models: Sequence["ModelType"]
+    description: str | None
     fields: Sequence[ModelField]
     arbitrary_fields_allowed: bool
 

--- a/spec2sdk/openapi/entities.py
+++ b/spec2sdk/openapi/entities.py
@@ -12,8 +12,6 @@ class Enumerator[T](Model):
 
 class DataType[T](Model):
     name: str | None
-    description: str | None
-    default_value: T | None
     enumerators: Sequence[Enumerator[T]] | None
 
 
@@ -56,10 +54,13 @@ class NullDataType(DataType[NoneType]):
 class ObjectProperty(Model):
     data_type: DataType
     name: str
+    description: str | None
+    default_value: Any
     is_required: bool
 
 
 class ObjectDataType(DataType):
+    description: str | None
     properties: Sequence[ObjectProperty]
     additional_properties: bool
 

--- a/spec2sdk/openapi/parsers.py
+++ b/spec2sdk/openapi/parsers.py
@@ -65,8 +65,6 @@ def parse_default_value[I, O](schema: dict, type_parser: Callable[[I], O] | None
 
 class CommonFields(TypedDict):
     name: str | None
-    description: str | None
-    default_value: Any | None
     enumerators: Sequence[Enumerator] | None
 
 
@@ -76,8 +74,6 @@ def parse_common_fields[I, O](
 ) -> CommonFields:
     return CommonFields(
         name=schema.get(SCHEMA_NAME_FIELD),
-        description=schema.get("description"),
-        default_value=parse_default_value(schema, type_parser),
         enumerators=parse_enumerators(schema, type_parser),
     )
 
@@ -143,10 +139,13 @@ def parse_object(schema: dict) -> ObjectDataType:
 
     return ObjectDataType(
         **parse_common_fields(schema=schema),
+        description=schema.get("description"),
         properties=tuple(
             ObjectProperty(
                 data_type=parsers.convert(property_schema),
                 name=property_name,
+                description=property_schema.get("description"),
+                default_value=parse_default_value(property_schema),
                 is_required=property_name in schema.get("required", ()),
             )
             for property_name, property_schema in schema.get("properties", {}).items()


### PR DESCRIPTION
`description` and `default` fields are actually do not belong to the type definition, but to the object or object's fields. Thus, `description` and `default` should not be a part of the type definition.