### PR TITLE
feat(spec2sdk): add special case for PHP multi-value query parameters in identifier name converter

### DIFF
--- a/spec2sdk/models/identifiers.py
+++ b/spec2sdk/models/identifiers.py
@@ -13,6 +13,10 @@ def make_identifier(name: str) -> str:
     and replacing invalid characters with underscore.
     """
 
+    # Special case for PHP multi-value query parameters
+    if name.endswith("[]"):
+        name = name.removesuffix("[]") + "s"
+
     name = "_".join(name_part for name_part in INVALID_CHARACTERS_PATTERN.split(name) if name_part)
 
     # Add underscore to the name if it's a valid Python keyword

--- a/tests/test_identifiers.py
+++ b/tests/test_identifiers.py
@@ -1,6 +1,10 @@
 from spec2sdk.models.identifiers import make_class_name, make_constant_name, make_identifier, make_variable_name
 
 
+def test_php_multi_value_query_parameters():
+    assert make_identifier("id[]") == "ids"
+
+
 def test_remove_invalid_leading_characters():
     assert make_identifier("12+34-_56Variable78Name90") == "Variable78Name90"
 


### PR DESCRIPTION
There can be a case when there are two query parameters with the same name.
```yaml
paths:
  /demo/:
    get:
      parameters:
        - name: id
          in: query
          required: false
          schema:
            type: integer
        - name: id[]
          in: query
          required: false
          schema:
            type: array
            items:
              type: integer
```
Current implementation generates two parameter with the same name (invalid characters are replaced with underscore, leading and trailing are removed).
```python
def demo(
    self,
    *,
    id: int | None = None,
    id: list[int] | None = None,
) -> DemoSchema:
    return self._api_client.send_request(
        method=HTTPMethod.GET,
        path="/demo/",
        query={
            "id": id,
            "id[]": id,
        },
        accept="application/json",
        response_type=DemoSchema,
    ).data
```
This cannot be solved by patching schema, only by generating a special name for such parameters.
