### PR TITLE
feat(spec2sdk): allow additionalProperties on object with properties

### DIFF
--- a/spec2sdk/openapi/parsers.py
+++ b/spec2sdk/openapi/parsers.py
@@ -131,11 +131,7 @@ def parse_null(schema: dict) -> NullDataType:
 
 @parsers.register(predicate=type_equals("object"))
 def parse_object(schema: dict) -> ObjectDataType:
-    additional_properties: bool = ("properties" not in schema) and schema.get("additionalProperties") in (
-        None,
-        True,
-        {},
-    )
+    additional_properties: bool = schema.get("additionalProperties") in (None, True, {})
 
     return ObjectDataType(
         **parse_common_fields(schema=schema),


### PR DESCRIPTION
I didn't find any strict definition of using `additionalProperties` along with `properties` in the OpenAPI specification. But it seems that it's allowed according to the JSON schema spec.

> Data types in the OAS are based on the types defined by the [JSON Schema Validation Specification Draft 2020-12](https://tools.ietf.org/html/draft-bhutton-json-schema-validation-00#section-6.1.1): “null”, “boolean”, “object”, “array”, “number”, “string”, or “integer”. Models are defined using the [Schema Object](https://spec.openapis.org/oas/v3.1.1.html#schema-object), which is a superset of the JSON Schema Specification Draft 2020-12.

https://spec.openapis.org/oas/v3.1.1.html#data-types

>  The behavior of this keyword depends on the presence and annotation results of "properties" and "patternProperties" within the same schema object. Validation with "additionalProperties" applies only to the child values of instance names that do not appear in the annotation results of either "properties" or "patternProperties".

https://datatracker.ietf.org/doc/html/draft-bhutton-json-schema-01#additionalProperties