### PR TITLE
feat(spec2sdk): remove special case for PHP multi-value query parameters in identifier name converter

### DIFF
--- a/spec2sdk/models/identifiers.py
+++ b/spec2sdk/models/identifiers.py
@@ -13,10 +13,6 @@ def make_identifier(name: str) -> str:
     and replacing invalid characters with underscore.
     """
 
-    # Special case for PHP multi-value query parameters
-    if name.endswith("[]"):
-        name = name.removesuffix("[]") + "s"
-
     name = "_".join(name_part for name_part in INVALID_CHARACTERS_PATTERN.split(name) if name_part)
 
     # Add underscore to the name if it's a valid Python keyword

--- a/tests/test_identifiers.py
+++ b/tests/test_identifiers.py
@@ -1,10 +1,6 @@
 from spec2sdk.models.identifiers import make_class_name, make_constant_name, make_identifier, make_variable_name
 
 
-def test_php_multi_value_query_parameters():
-    assert make_identifier("id[]") == "ids"
-
-
 def test_remove_invalid_leading_characters():
     assert make_identifier("12+34-_56Variable78Name90") == "Variable78Name90"
 


### PR DESCRIPTION
Such cases should be handled either by patching OpenAPI specification or by using choosing correct names for array identifiers.