### PR TITLE
Bump GitHub runner to ubuntu-latest

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   publish-package:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     timeout-minutes: 10
 
     steps:


### PR DESCRIPTION
Replaced `runs-on: ubuntu-24.04` with `ubuntu-latest`.