### PR TITLE
feat(spec2sdk): change ruff formatting order

### DIFF
--- a/spec2sdk/main.py
+++ b/spec2sdk/main.py
@@ -19,15 +19,15 @@ def format_files(path: Path):
 
     # Formatting and linting explanation:
     # 1. Break long strings with black. Remove black call once ruff can break long strings.
-    # 2. Format the code [line will be a 120 character]
-    # 3. Add trailing comma [line will be a 121 character]
-    # 4. Format the code [line will be a 120 character]
-    # 5. Apply linting auto fixes, and then check if the generated code follow the linting rules
+    # 2. Add trailing comma [line might be longer than 121 character]
+    # 3. Format the code [line will be a 120 character]
+    # 4. Apply linting auto fixes, and then check if the generated code follow the linting rules
+    # 5. Format the code
     run_formatter("black --preview --unstable --line-length 120")
-    run_formatter("ruff format")
     run_formatter("ruff check --select COM812 --fix")
     run_formatter("ruff format")
     run_formatter("ruff check --fix")
+    run_formatter("ruff format")
 
 
 def generate(schema_url: str, output_dir: Path):


### PR DESCRIPTION
Change the order of formatting calls to match the calls order in the file watchers we use. Otherwise, it can sometimes lead to a not fully formatted files (see https://github.com/moneymeets/fondsnet-sdk/actions/runs/18191758364/job/51788177410). Since file watchers runs automatically on the local machine we don't see any problems. But CI fails because of a problem with a different ruff calls order.